### PR TITLE
fix: Removed requeue message if event data empty

### DIFF
--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/GenerateReceiptPdf.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/GenerateReceiptPdf.java
@@ -48,11 +48,14 @@ public class GenerateReceiptPdf {
      * If everything succeeded the receipt's status will be updated to GENERATED and saved to CosmosDB
      * #
      * The message is re-sent to the queue in case of errors like:
-     * the receipt is not found;
-     * the receipt has NOT status INSERTED or RETRY;
-     * there is an error generating at least one pdf;
-     * there is an error saving at least one pdf to blob storage;
-     * errors processing the data;
+     * - there is an error generating at least one pdf;
+     * - there is an error saving at least one pdf to blob storage;
+     * - errors processing the data;
+     * #
+     * The receipt is discarded in case of:
+     * - the receipt is null
+     * - the receipt has not valid event data
+     * - the receipt's status is not INSERTED or RETRY
      * #
      * After too many retry the receipt's status will be updated to FAILED
      *


### PR DESCRIPTION
#### List of Changes
If the receipt, found with the given id, hasn't got any event data it will be discarded and NOT resent to the queue as previously

#### Motivation and Context

Given an incorrect receipt it would cause a loop re-queueing the message

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
