### PR TITLE
chore: [PAGOPA-3667] Query optimization

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfdatastore
 description: Microservice description
 type: application
-version: 0.159.0
-appVersion: 1.17.9
+version: 0.160.0
+appVersion: 1.17.9-1-PAGOPA-3625-query-optimization
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfdatastore
 description: Microservice description
 type: application
-version: 0.163.0
-appVersion: 1.17.10
+version: 0.164.0
+appVersion: 1.17.10-1-PAGOPA-3625-query-optimization
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.10"
+    tag: "1.17.10-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.9"
+    tag: "1.17.9-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.10"
+    tag: "1.17.10-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.9"
+    tag: "1.17.9-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.10"
+    tag: "1.17.10-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.9"
+    tag: "1.17.9-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "Receipts Datastore Helpdesk",
     "description": "Microservice for exposing REST APIs about receipts datastore helpdesk.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.17.10"
+    "version": "1.17.10-1-PAGOPA-3625-query-optimization"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "Receipts Datastore Helpdesk",
     "description": "Microservice for exposing REST APIs about receipts datastore helpdesk.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.17.9"
+    "version": "1.17.9-1-PAGOPA-3625-query-optimization"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.receipt</groupId>
     <artifactId>receipt-pdf-datastore</artifactId>
-    <version>1.17.10</version>
+    <version>1.17.10-1-PAGOPA-3625-query-optimization</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-datastore</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.receipt</groupId>
     <artifactId>receipt-pdf-datastore</artifactId>
-    <version>1.17.9</version>
+    <version>1.17.9-1-PAGOPA-3625-query-optimization</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-datastore</name>

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
@@ -3,7 +3,6 @@ package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
@@ -22,10 +21,8 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
 
     private static BizEventCosmosClientImpl instance;
 
-    private final String databaseId = System.getenv("COSMOS_BIZ_EVENT_DB_NAME");
-    private final String containerId = System.getenv("COSMOS_BIZ_EVENT_CONTAINER_NAME");
-
     private final CosmosClient cosmosClient;
+    private final CosmosContainer bizEventContainer;
 
     private BizEventCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_BIZ_EVENT_KEY");
@@ -37,10 +34,20 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
                 .key(azureKey)
                 .preferredRegions(List.of(readRegion))
                 .buildClient();
+
+        String containerId = System.getenv("COSMOS_BIZ_EVENT_CONTAINER_NAME");
+        String databaseId = System.getenv("COSMOS_BIZ_EVENT_DB_NAME");
+
+        this.bizEventContainer = this.cosmosClient.getDatabase(databaseId).getContainer(containerId);
     }
 
-    public BizEventCosmosClientImpl(CosmosClient cosmosClient) {
+    /**
+     * Test-only constructor. Package-private visibility so it is only reachable from tests
+     * in the same package.
+     */
+    BizEventCosmosClientImpl(CosmosClient cosmosClient, CosmosContainer bizEventContainer) {
         this.cosmosClient = cosmosClient;
+        this.bizEventContainer = bizEventContainer;
     }
 
     public static BizEventCosmosClientImpl getInstance() {
@@ -55,11 +62,8 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
      */
     @Override
     public BizEvent getBizEventDocument(String bizEventId) throws BizEventNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
         try {
-            return cosmosContainer.readItem(bizEventId, new PartitionKey(bizEventId), BizEvent.class).getItem();
+            return bizEventContainer.readItem(bizEventId, new PartitionKey(bizEventId), BizEvent.class).getItem();
         } catch (CosmosException e) {
             throw new BizEventNotFoundException("Document not found in the defined container", e);
         }
@@ -70,9 +74,6 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
      */
     @Override
     public List<BizEvent> getAllCartBizEventDocument(String transactionId) {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
         //Build query
         SqlQuerySpec querySpec = new SqlQuerySpec(
                 "SELECT * FROM c WHERE c.transactionDetails.transaction.transactionId = @transactionId",
@@ -80,7 +81,7 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
         );
 
         //Query the container
-        return cosmosContainer
+        return bizEventContainer
                 .queryItems(querySpec, new CosmosQueryRequestOptions(), BizEvent.class)
                 .stream().limit(6)
                 .toList();

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
@@ -68,6 +68,9 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
         try {
             return bizEventContainer.readItem(bizEventId, new PartitionKey(bizEventId), BizEvent.class).getItem();
         } catch (CosmosException e) {
+            if (e.getStatusCode() != 404) {
+                throw e;
+            }
             throw new BizEventNotFoundException("Document not found in the defined container", e);
         }
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
@@ -19,8 +19,6 @@ import java.util.List;
  */
 public class BizEventCosmosClientImpl implements BizEventCosmosClient {
 
-    private static BizEventCosmosClientImpl instance;
-
     private final CosmosClient cosmosClient;
     private final CosmosContainer bizEventContainer;
 
@@ -35,8 +33,8 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
                 .preferredRegions(List.of(readRegion))
                 .buildClient();
 
-        String containerId = System.getenv("COSMOS_BIZ_EVENT_CONTAINER_NAME");
         String databaseId = System.getenv("COSMOS_BIZ_EVENT_DB_NAME");
+        String containerId = System.getenv("COSMOS_BIZ_EVENT_CONTAINER_NAME");
 
         this.bizEventContainer = this.cosmosClient.getDatabase(databaseId).getContainer(containerId);
     }
@@ -51,10 +49,15 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
     }
 
     public static BizEventCosmosClientImpl getInstance() {
-        if (instance == null) {
-            instance = new BizEventCosmosClientImpl();
-        }
-        return instance;
+        return SingletonHelper.INSTANCE;
+    }
+
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final BizEventCosmosClientImpl INSTANCE = new BizEventCosmosClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
@@ -7,6 +7,8 @@ import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
 import it.gov.pagopa.receipt.pdf.datastore.client.BizEventCosmosClient;
 import it.gov.pagopa.receipt.pdf.datastore.entity.event.BizEvent;
 import it.gov.pagopa.receipt.pdf.datastore.exception.BizEventNotFoundException;
@@ -72,12 +74,14 @@ public class BizEventCosmosClientImpl implements BizEventCosmosClient {
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
 
         //Build query
-        String query = String.format("SELECT * FROM c WHERE c.transactionDetails.transaction.transactionId = '%s'",
-                transactionId);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c WHERE c.transactionDetails.transaction.transactionId = @transactionId",
+                List.of(new SqlParameter("@transactionId", transactionId))
+        );
 
         //Query the container
         return cosmosContainer
-                .queryItems(query, new CosmosQueryRequestOptions(), BizEvent.class)
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), BizEvent.class)
                 .stream().limit(6)
                 .toList();
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImpl.java
@@ -1,8 +1,8 @@
 package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
@@ -19,32 +19,32 @@ import java.util.List;
  */
 public class BizEventCosmosClientImpl implements BizEventCosmosClient {
 
-    private final CosmosClient cosmosClient;
     private final CosmosContainer bizEventContainer;
 
+    @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
     private BizEventCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_BIZ_EVENT_KEY");
         String serviceEndpoint = System.getenv("COSMOS_BIZ_EVENT_SERVICE_ENDPOINT");
         String readRegion = System.getenv("COSMOS_BIZ_EVENT_READ_REGION");
 
-        this.cosmosClient = new CosmosClientBuilder()
-                .endpoint(serviceEndpoint)
-                .key(azureKey)
-                .preferredRegions(List.of(readRegion))
-                .buildClient();
-
         String databaseId = System.getenv("COSMOS_BIZ_EVENT_DB_NAME");
         String containerId = System.getenv("COSMOS_BIZ_EVENT_CONTAINER_NAME");
 
-        this.bizEventContainer = this.cosmosClient.getDatabase(databaseId).getContainer(containerId);
+        CosmosDatabase database = new CosmosClientBuilder()
+                .endpoint(serviceEndpoint)
+                .key(azureKey)
+                .preferredRegions(List.of(readRegion))
+                .buildClient()
+                .getDatabase(databaseId);
+
+        this.bizEventContainer = database.getContainer(containerId);
     }
 
     /**
      * Test-only constructor. Package-private visibility so it is only reachable from tests
      * in the same package.
      */
-    BizEventCosmosClientImpl(CosmosClient cosmosClient, CosmosContainer bizEventContainer) {
-        this.cosmosClient = cosmosClient;
+    BizEventCosmosClientImpl(CosmosContainer bizEventContainer) {
         this.bizEventContainer = bizEventContainer;
     }
 

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartQueueClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartQueueClientImpl.java
@@ -14,8 +14,6 @@ import java.time.temporal.ChronoUnit;
  */
 public class CartQueueClientImpl implements CartQueueClient {
 
-    private static CartQueueClientImpl instance;
-
     private final int cartQueueDelay = Integer.parseInt(System.getenv().getOrDefault("CART_RECEIPT_QUEUE_DELAY", "1"));
 
     private final QueueClient cartQueueClient;
@@ -35,11 +33,15 @@ public class CartQueueClientImpl implements CartQueueClient {
     }
 
     public static CartQueueClientImpl getInstance() {
-        if (instance == null) {
-            instance = new CartQueueClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final CartQueueClientImpl INSTANCE = new CartQueueClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
 
-
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
     private final String millisDiff = System.getenv().getOrDefault("MAX_DATE_DIFF_MILLIS", "1800000");

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -1,7 +1,6 @@
 package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 
 import com.azure.cosmos.ConsistencyLevel;
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -36,27 +35,27 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
     private final String numDaysRecoverFailed = System.getenv().getOrDefault("RECOVER_FAILED_MASSIVE_MAX_DAYS", "0");
     private final String numDaysRecoverNotNotified = System.getenv().getOrDefault("RECOVER_NOT_NOTIFIED_MASSIVE_MAX_DAYS", "0");
 
-    private final CosmosClient cosmosClient;
     private final CosmosContainer cartForReceiptContainer;
     private final CosmosContainer cartReceiptsErrorsContainer;
 
+    @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
     private CartReceiptsCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_RECEIPT_KEY");
         String serviceEndpoint = System.getenv("COSMOS_RECEIPT_SERVICE_ENDPOINT");
         String readRegion = System.getenv("COSMOS_RECEIPT_READ_REGION");
 
-        this.cosmosClient = new CosmosClientBuilder()
-                .endpoint(serviceEndpoint)
-                .key(azureKey)
-                .consistencyLevel(ConsistencyLevel.BOUNDED_STALENESS)
-                .preferredRegions(List.of(readRegion))
-                .buildClient();
-
         String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
         String cartForReceiptContainerName = System.getenv("CART_FOR_RECEIPT_CONTAINER_NAME");
         String cartReceiptsMessageErrorsContainerName = System.getenv("CART_RECEIPTS_MESSAGE_ERRORS_CONTAINER_NAME");
 
-        CosmosDatabase database = this.cosmosClient.getDatabase(databaseId);
+        CosmosDatabase database = new CosmosClientBuilder()
+                .endpoint(serviceEndpoint)
+                .key(azureKey)
+                .consistencyLevel(ConsistencyLevel.BOUNDED_STALENESS)
+                .preferredRegions(List.of(readRegion))
+                .buildClient()
+                .getDatabase(databaseId);
+
         this.cartForReceiptContainer = database.getContainer(cartForReceiptContainerName);
         this.cartReceiptsErrorsContainer = database.getContainer(cartReceiptsMessageErrorsContainerName);
     }
@@ -66,11 +65,9 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
      * in the same package.
      */
     CartReceiptsCosmosClientImpl(
-            CosmosClient cosmosClient,
             CosmosContainer cartForReceiptContainer,
             CosmosContainer cartReceiptsErrorsContainer
     ) {
-        this.cosmosClient = cosmosClient;
         this.cartForReceiptContainer = cartForReceiptContainer;
         this.cartReceiptsErrorsContainer = cartReceiptsErrorsContainer;
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -12,6 +12,8 @@ import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.FeedResponse;
 import com.azure.cosmos.models.PartitionKey;
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.microsoft.azure.functions.HttpStatus;
 import it.gov.pagopa.receipt.pdf.datastore.client.CartReceiptsCosmosClient;
 import it.gov.pagopa.receipt.pdf.datastore.entity.cart.CartForReceipt;
@@ -22,6 +24,7 @@ import it.gov.pagopa.receipt.pdf.datastore.exception.CartNotFoundException;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 
 public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
@@ -33,8 +36,8 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
 
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
-    private final String millisDiff = System.getenv("MAX_DATE_DIFF_MILLIS");
-    private final String millisNotifyDif = System.getenv("MAX_DATE_DIFF_NOTIFY_MILLIS");
+    private final String millisDiff = System.getenv().getOrDefault("MAX_DATE_DIFF_MILLIS", "1800000");
+    private final String millisNotifyDif = System.getenv().getOrDefault("MAX_DATE_DIFF_NOTIFY_MILLIS", "1800000");
     private final String numDaysRecoverFailed = System.getenv().getOrDefault("RECOVER_FAILED_MASSIVE_MAX_DAYS", "0");
     private final String numDaysRecoverNotNotified = System.getenv().getOrDefault("RECOVER_NOT_NOTIFIED_MASSIVE_MAX_DAYS", "0");
 
@@ -117,11 +120,24 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
             String continuationToken,
             Integer pageSize
     ) {
-        String query = String.format("SELECT * FROM c WHERE (c.status = '%s' or c.status = '%s') AND c.inserted_at >= %s",
-                CartStatusType.FAILED, CartStatusType.NOT_QUEUE_SENT,
-                OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(
-                        Long.parseLong(numDaysRecoverFailed)).toInstant().toEpochMilli());
-        return executePagedQuery(cartForReceiptContainerName, query, continuationToken, pageSize);
+        long daysAgo = OffsetDateTime.now()
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverFailed))
+                .toInstant()
+                .toEpochMilli();
+
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE (c.status = @statusFailed OR c.status = @statusNotQueueSent) " +
+                        "   AND c.inserted_at >= @minInsertedAt ",
+                Arrays.asList(
+                        new SqlParameter("@statusFailed", CartStatusType.FAILED.name()),
+                        new SqlParameter("@statusNotQueueSent", CartStatusType.NOT_QUEUE_SENT.name()),
+                        new SqlParameter("@minInsertedAt", daysAgo)
+                )
+        );
+
+        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -133,14 +149,29 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
             Integer pageSize
     ) {
         OffsetDateTime currentDateTime = OffsetDateTime.now();
-        long now = currentDateTime.toInstant().toEpochMilli();
-        long daysAgo = currentDateTime.truncatedTo(ChronoUnit.DAYS).minusDays(Long.parseLong(numDaysRecoverFailed)).toInstant().toEpochMilli();
+        long daysAgo = currentDateTime
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverFailed))
+                .toInstant()
+                .toEpochMilli();
 
-        String query = String.format(
-                "SELECT * FROM c WHERE (c.status = '%s' or c.status = '%s') AND c.inserted_at >= %s AND ( %s - c.inserted_at) >= %s",
-                CartStatusType.INSERTED, CartStatusType.WAITING_FOR_BIZ_EVENT, daysAgo, now, millisDiff);
+        // (now - c.inserted_at) >= millisDiff  <=>  c.inserted_at <= now - millisDiff
+        long maxInsertedAt = currentDateTime.toInstant().toEpochMilli() - Long.parseLong(millisDiff);
 
-        return executePagedQuery(cartForReceiptContainerName, query, continuationToken, pageSize);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE (c.status = @statusInserted OR c.status = @statusWaitingForBizEvent) " +
+                        "  AND c.inserted_at >= @minInsertedAt " +
+                        "  AND c.inserted_at <= @maxInsertedAt",
+                Arrays.asList(
+                        new SqlParameter("@statusInserted", CartStatusType.INSERTED.name()),
+                        new SqlParameter("@statusWaitingForBizEvent", CartStatusType.WAITING_FOR_BIZ_EVENT.name()),
+                        new SqlParameter("@minInsertedAt", daysAgo),
+                        new SqlParameter("@maxInsertedAt", maxInsertedAt)
+                )
+        );
+
+        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
     }
 
     @Override
@@ -148,12 +179,23 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
             String continuationToken,
             Integer pageSize
     ) {
-        long daysAgo = OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(Long.parseLong(numDaysRecoverNotNotified)).toInstant().toEpochMilli();
+        long daysAgo = OffsetDateTime.now()
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverNotNotified))
+                .toInstant()
+                .toEpochMilli();
 
-        String query = String.format("SELECT * FROM c WHERE c.status = '%s' AND c.generated_at >= %s",
-                CartStatusType.IO_ERROR_TO_NOTIFY, daysAgo);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE c.status = @statusIoErrorToNotify " +
+                        "  AND c.generated_at >= @generatedAt",
+                Arrays.asList(
+                        new SqlParameter("@statusIoErrorToNotify", CartStatusType.IO_ERROR_TO_NOTIFY.name()),
+                        new SqlParameter("@generatedAt", daysAgo)
+                )
+        );
 
-        return executePagedQuery(cartForReceiptContainerName, query, continuationToken, pageSize);
+        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
     }
 
     @Override
@@ -162,13 +204,28 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
             Integer pageSize
     ) {
         OffsetDateTime currentDateTime = OffsetDateTime.now();
-        long now = currentDateTime.toInstant().toEpochMilli();
-        long daysAgo = currentDateTime.truncatedTo(ChronoUnit.DAYS).minusDays(Long.parseLong(numDaysRecoverNotNotified)).toInstant().toEpochMilli();
+        long daysAgo = currentDateTime
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverNotNotified))
+                .toInstant()
+                .toEpochMilli();
 
-        String query = String.format("SELECT * FROM c WHERE (c.status = '%s' AND c.generated_at >= %s AND ( %s - c.generated_at) >= %s)",
-                CartStatusType.GENERATED, daysAgo, now, millisNotifyDif);
+        // (now - c.generated_at) >= millisNotifyDif  <=>  c.generated_at <= now - millisNotifyDif
+        long maxGeneratedAt = currentDateTime.toInstant().toEpochMilli() - Long.parseLong(millisNotifyDif);
 
-        return executePagedQuery(cartForReceiptContainerName, query, continuationToken, pageSize);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE c.status = @statusGenerated " +
+                        "  AND c.generated_at >= @minGeneratedAt " +
+                        "  AND c.generated_at <= @maxGeneratedAt",
+                Arrays.asList(
+                        new SqlParameter("@statusGenerated", CartStatusType.GENERATED.name()),
+                        new SqlParameter("@minGeneratedAt", daysAgo),
+                        new SqlParameter("@maxGeneratedAt", maxGeneratedAt)
+                )
+        );
+
+        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -177,13 +234,13 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
 
     private Iterable<FeedResponse<CartForReceipt>> executePagedQuery(
             String containerName,
-            String query,
+            SqlQuerySpec querySpec,
             String continuationToken,
             Integer pageSize
     ) {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
         return cosmosDatabase.getContainer(containerName)
-                .queryItems(query, new CosmosQueryRequestOptions(), CartForReceipt.class)
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), CartForReceipt.class)
                 .iterableByPage(continuationToken, pageSize);
     }
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -88,6 +88,9 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
         try {
             return cartForReceiptContainer.readItem(cartId, new PartitionKey(cartId), CartForReceipt.class).getItem();
         } catch (CosmosException e) {
+            if (e.getStatusCode() != 404) {
+                throw e;
+            }
             throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
         }
     }
@@ -112,6 +115,9 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
         try {
             return cartReceiptsErrorsContainer.readItem(cartId, new PartitionKey(cartId), CartReceiptError.class).getItem();
         } catch (CosmosException e) {
+            if (e.getStatusCode() != 404) {
+                throw e;
+            }
             throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
         }
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -22,7 +22,6 @@ import it.gov.pagopa.receipt.pdf.datastore.exception.CartNotFoundException;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 
 public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
@@ -140,7 +139,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 "SELECT * FROM c " +
                         "WHERE (c.status = @statusFailed OR c.status = @statusNotQueueSent) " +
                         "   AND c.inserted_at >= @minInsertedAt ",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusFailed", CartStatusType.FAILED.name()),
                         new SqlParameter("@statusNotQueueSent", CartStatusType.NOT_QUEUE_SENT.name()),
                         new SqlParameter("@minInsertedAt", daysAgo)
@@ -173,7 +172,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                         "WHERE (c.status = @statusInserted OR c.status = @statusWaitingForBizEvent) " +
                         "  AND c.inserted_at >= @minInsertedAt " +
                         "  AND c.inserted_at <= @maxInsertedAt",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusInserted", CartStatusType.INSERTED.name()),
                         new SqlParameter("@statusWaitingForBizEvent", CartStatusType.WAITING_FOR_BIZ_EVENT.name()),
                         new SqlParameter("@minInsertedAt", daysAgo),
@@ -199,7 +198,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 "SELECT * FROM c " +
                         "WHERE c.status = @statusIoErrorToNotify " +
                         "  AND c.generated_at >= @generatedAt",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusIoErrorToNotify", CartStatusType.IO_ERROR_TO_NOTIFY.name()),
                         new SqlParameter("@generatedAt", daysAgo)
                 )
@@ -228,7 +227,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                         "WHERE c.status = @statusGenerated " +
                         "  AND c.generated_at >= @minGeneratedAt " +
                         "  AND c.generated_at <= @maxGeneratedAt",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusGenerated", CartStatusType.GENERATED.name()),
                         new SqlParameter("@minGeneratedAt", daysAgo),
                         new SqlParameter("@maxGeneratedAt", maxGeneratedAt)

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -29,9 +29,6 @@ import java.util.List;
 public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
 
     private static CartReceiptsCosmosClientImpl instance;
-    private final String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
-    private final String cartForReceiptContainerName = System.getenv("CART_FOR_RECEIPT_CONTAINER_NAME");
-    private final String cartReceiptsMessageErrorsContainerName = System.getenv("CART_RECEIPTS_MESSAGE_ERRORS_CONTAINER_NAME");
 
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
@@ -41,6 +38,8 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
     private final String numDaysRecoverNotNotified = System.getenv().getOrDefault("RECOVER_NOT_NOTIFIED_MASSIVE_MAX_DAYS", "0");
 
     private final CosmosClient cosmosClient;
+    private final CosmosContainer cartForReceiptContainer;
+    private final CosmosContainer cartReceiptsErrorsContainer;
 
     private CartReceiptsCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_RECEIPT_KEY");
@@ -53,10 +52,28 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 .consistencyLevel(ConsistencyLevel.BOUNDED_STALENESS)
                 .preferredRegions(List.of(readRegion))
                 .buildClient();
+
+        String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
+        String cartForReceiptContainerName = System.getenv("CART_FOR_RECEIPT_CONTAINER_NAME");
+        String cartReceiptsMessageErrorsContainerName = System.getenv("CART_RECEIPTS_MESSAGE_ERRORS_CONTAINER_NAME");
+
+        CosmosDatabase database = this.cosmosClient.getDatabase(databaseId);
+        this.cartForReceiptContainer = database.getContainer(cartForReceiptContainerName);
+        this.cartReceiptsErrorsContainer = database.getContainer(cartReceiptsMessageErrorsContainerName);
     }
 
-    public CartReceiptsCosmosClientImpl(CosmosClient cosmosClient) {
+    /**
+     * Test-only constructor. Package-private visibility so it is only reachable from tests
+     * in the same package.
+     */
+    CartReceiptsCosmosClientImpl(
+            CosmosClient cosmosClient,
+            CosmosContainer cartForReceiptContainer,
+            CosmosContainer cartReceiptsErrorsContainer
+    ) {
         this.cosmosClient = cosmosClient;
+        this.cartForReceiptContainer = cartForReceiptContainer;
+        this.cartReceiptsErrorsContainer = cartReceiptsErrorsContainer;
     }
 
     public static CartReceiptsCosmosClientImpl getInstance() {
@@ -69,11 +86,8 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
 
     @Override
     public CartForReceipt getCartItem(String cartId) throws CartNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(cartForReceiptContainerName);
-
         try {
-            return cosmosContainer.readItem(cartId, new PartitionKey(cartId), CartForReceipt.class).getItem();
+            return cartForReceiptContainer.readItem(cartId, new PartitionKey(cartId), CartForReceipt.class).getItem();
         } catch (CosmosException e) {
             throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
         }
@@ -84,10 +98,8 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
      */
     @Override
     public CosmosItemResponse<CartForReceipt> updateCart(CartForReceipt receipt) throws CartConcurrentUpdateException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(cartForReceiptContainerName);
         try {
-            return cosmosContainer.upsertItem(receipt, new CosmosItemRequestOptions().setIfMatchETag(receipt.get_etag()));
+            return cartForReceiptContainer.upsertItem(receipt, new CosmosItemRequestOptions().setIfMatchETag(receipt.get_etag()));
         } catch (PreconditionFailedException e) {
             throw new CartConcurrentUpdateException("The cart has been updated since the last fetch", e);
         }
@@ -98,11 +110,8 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
      */
     @Override
     public CartReceiptError getCartReceiptError(String cartId) throws CartNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(cartReceiptsMessageErrorsContainerName);
-
         try {
-            return cosmosContainer.readItem(cartId, new PartitionKey(cartId), CartReceiptError.class).getItem();
+            return cartReceiptsErrorsContainer.readItem(cartId, new PartitionKey(cartId), CartReceiptError.class).getItem();
         } catch (CosmosException e) {
             throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
         }
@@ -133,7 +142,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 )
         );
 
-        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -167,7 +176,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 )
         );
 
-        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     @Override
@@ -191,7 +200,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 )
         );
 
-        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     @Override
@@ -221,7 +230,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
                 )
         );
 
-        return executePagedQuery(cartForReceiptContainerName, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -229,13 +238,11 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
      */
 
     private Iterable<FeedResponse<CartForReceipt>> executePagedQuery(
-            String containerName,
             SqlQuerySpec querySpec,
             String continuationToken,
             Integer pageSize
     ) {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        return cosmosDatabase.getContainer(containerName)
+        return cartForReceiptContainer
                 .queryItems(querySpec, new CosmosQueryRequestOptions(), CartForReceipt.class)
                 .iterableByPage(continuationToken, pageSize);
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -14,7 +14,6 @@ import com.azure.cosmos.models.FeedResponse;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
-import com.microsoft.azure.functions.HttpStatus;
 import it.gov.pagopa.receipt.pdf.datastore.client.CartReceiptsCosmosClient;
 import it.gov.pagopa.receipt.pdf.datastore.entity.cart.CartForReceipt;
 import it.gov.pagopa.receipt.pdf.datastore.entity.cart.CartStatusType;
@@ -76,7 +75,7 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
         try {
             return cosmosContainer.readItem(cartId, new PartitionKey(cartId), CartForReceipt.class).getItem();
         } catch (CosmosException e) {
-            throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG);
+            throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
         }
     }
 
@@ -102,14 +101,11 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(cartReceiptsMessageErrorsContainerName);
 
-        CosmosItemResponse<CartReceiptError> response =
-                cosmosContainer.readItem(cartId, new PartitionKey(cartId), CartReceiptError.class);
-
-        if (response.getStatusCode() == HttpStatus.OK.value()) {
-            return response.getItem();
+        try {
+            return cosmosContainer.readItem(cartId, new PartitionKey(cartId), CartReceiptError.class).getItem();
+        } catch (CosmosException e) {
+            throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
         }
-
-        throw new CartNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG);
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
 
-    private static CartReceiptsCosmosClientImpl instance;
 
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
@@ -77,11 +76,15 @@ public class CartReceiptsCosmosClientImpl implements CartReceiptsCosmosClient {
     }
 
     public static CartReceiptsCosmosClientImpl getInstance() {
-        if (instance == null) {
-            instance = new CartReceiptsCosmosClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final CartReceiptsCosmosClientImpl INSTANCE = new CartReceiptsCosmosClientImpl();
     }
 
     @Override

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/PDVTokenizerClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/PDVTokenizerClientImpl.java
@@ -17,14 +17,15 @@ import java.net.http.HttpResponse;
  */
 public class PDVTokenizerClientImpl implements PDVTokenizerClient {
 
+    private final Logger logger = LoggerFactory.getLogger(PDVTokenizerClientImpl.class);
+
     private static final String BASE_PATH = System.getenv().getOrDefault("PDV_TOKENIZER_BASE_PATH", "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1");
     private static final String SUBSCRIPTION_KEY = System.getenv().getOrDefault("PDV_TOKENIZER_SUBSCRIPTION_KEY", "");
     private static final String SUBSCRIPTION_KEY_HEADER = System.getenv().getOrDefault("TOKENIZER_APIM_HEADER_KEY", "x-api-key");
     private static final String SEARCH_TOKEN_ENDPOINT = System.getenv().getOrDefault("PDV_TOKENIZER_SEARCH_TOKEN_ENDPOINT", "/tokens/search");
     private static final String FIND_PII_ENDPOINT = System.getenv().getOrDefault("PDV_TOKENIZER_FIND_PII_ENDPOINT", "/tokens/%s/pii");
     private static final String CREATE_TOKEN_ENDPOINT = System.getenv().getOrDefault("PDV_TOKENIZER_CREATE_TOKEN_ENDPOINT", "/tokens");
-    private static PDVTokenizerClientImpl instance;
-    private final Logger logger = LoggerFactory.getLogger(PDVTokenizerClientImpl.class);
+
     private final HttpClient client;
 
     private PDVTokenizerClientImpl() {
@@ -38,10 +39,15 @@ public class PDVTokenizerClientImpl implements PDVTokenizerClient {
     }
 
     public static PDVTokenizerClientImpl getInstance() {
-        if (instance == null) {
-            instance = new PDVTokenizerClientImpl();
-        }
-        return instance;
+        return SingletonHelper.INSTANCE;
+    }
+
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final PDVTokenizerClientImpl INSTANCE = new PDVTokenizerClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -35,27 +34,27 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     private final String numDaysRecoverFailed = System.getenv().getOrDefault("RECOVER_FAILED_MASSIVE_MAX_DAYS", "0");
     private final String numDaysRecoverNotNotified = System.getenv().getOrDefault("RECOVER_NOT_NOTIFIED_MASSIVE_MAX_DAYS", "0");
 
-    private final CosmosClient cosmosClient;
     private final CosmosContainer receiptContainer;
     private final CosmosContainer receiptErrorContainer;
 
+    @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
     private ReceiptCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_RECEIPT_KEY");
         String serviceEndpoint = System.getenv("COSMOS_RECEIPT_SERVICE_ENDPOINT");
         String readRegion = System.getenv("COSMOS_RECEIPT_READ_REGION");
-
-        this.cosmosClient = new CosmosClientBuilder()
-                .endpoint(serviceEndpoint)
-                .key(azureKey)
-                .preferredRegions(List.of(readRegion))
-                .buildClient();
 
         String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
         String containerId = System.getenv("COSMOS_RECEIPT_CONTAINER_NAME");
         String containerReceiptErrorId = System.getenv()
                 .getOrDefault("COSMOS_RECEIPT_ERROR_CONTAINER_NAME", "receipts-message-errors");
 
-        CosmosDatabase database = this.cosmosClient.getDatabase(databaseId);
+        CosmosDatabase database = new CosmosClientBuilder()
+                .endpoint(serviceEndpoint)
+                .key(azureKey)
+                .preferredRegions(List.of(readRegion))
+                .buildClient()
+                .getDatabase(databaseId);
+
         this.receiptContainer = database.getContainer(containerId);
         this.receiptErrorContainer = database.getContainer(containerReceiptErrorId);
     }
@@ -65,11 +64,9 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      * in the same package.
      */
     ReceiptCosmosClientImpl(
-            CosmosClient cosmosClient,
             CosmosContainer receiptContainer,
             CosmosContainer receiptErrorContainer
     ) {
-        this.cosmosClient = cosmosClient;
         this.receiptContainer = receiptContainer;
         this.receiptErrorContainer = receiptErrorContainer;
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -5,7 +5,6 @@ import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
-import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.FeedResponse;
@@ -79,7 +78,10 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
         try {
             return cosmosContainer.readItem(eventId, new PartitionKey(eventId), Receipt.class)
                     .getItem();
-        } catch (NotFoundException e) {
+        } catch (CosmosException e) {
+            if (e.getStatusCode() != 404) {
+                throw new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
+            }
             // if not found use fallback query
             SqlQuerySpec querySpec = new SqlQuerySpec(
                     "SELECT * FROM c WHERE c.eventId = @eventId",

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -28,8 +28,6 @@ import java.util.Optional;
  */
 public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
 
-    private static ReceiptCosmosClientImpl instance;
-
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
     private final String millisDiff = System.getenv().getOrDefault("MAX_DATE_DIFF_MILLIS", "1800000");
@@ -77,11 +75,15 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     }
 
     public static ReceiptCosmosClientImpl getInstance() {
-        if (instance == null) {
-            instance = new ReceiptCosmosClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final ReceiptCosmosClientImpl INSTANCE = new ReceiptCosmosClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -7,6 +7,8 @@ import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.FeedResponse;
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
 import it.gov.pagopa.receipt.pdf.datastore.client.ReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.ReceiptError;
@@ -15,6 +17,7 @@ import it.gov.pagopa.receipt.pdf.datastore.exception.ReceiptNotFoundException;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,8 +34,8 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
 
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
-    private final String millisDiff = System.getenv("MAX_DATE_DIFF_MILLIS");
-    private final String millisNotifyDif = System.getenv("MAX_DATE_DIFF_NOTIFY_MILLIS");
+    private final String millisDiff = System.getenv().getOrDefault("MAX_DATE_DIFF_MILLIS", "1800000");
+    private final String millisNotifyDif = System.getenv().getOrDefault("MAX_DATE_DIFF_NOTIFY_MILLIS", "1800000");
     private final String numDaysRecoverFailed = System.getenv().getOrDefault("RECOVER_FAILED_MASSIVE_MAX_DAYS", "0");
     private final String numDaysRecoverNotNotified = System.getenv().getOrDefault("RECOVER_NOT_NOTIFIED_MASSIVE_MAX_DAYS", "0");
 
@@ -67,7 +70,12 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     @Override
     public Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException {
-        return getDocumentByFilter(containerId, "eventId", eventId, Receipt.class)
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c WHERE c.eventId = @eventId",
+                List.of(new SqlParameter("@eventId", eventId))
+        );
+
+        return getDocumentByFilter(containerId, querySpec, Receipt.class)
                 .orElseThrow(() -> new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG));
     }
 
@@ -75,8 +83,13 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      * {@inheritDoc}
      */
     @Override
-    public ReceiptError getReceiptError(String bizEventId) throws  ReceiptNotFoundException {
-        return getDocumentByFilter(containerReceiptErrorId, "bizEventId", bizEventId, ReceiptError.class)
+    public ReceiptError getReceiptError(String bizEventId) throws ReceiptNotFoundException {
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c WHERE c.bizEventId = @bizEventId",
+                List.of(new SqlParameter("@bizEventId", bizEventId))
+        );
+
+        return getDocumentByFilter(containerReceiptErrorId, querySpec, ReceiptError.class)
                 .orElseThrow(() -> new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG));
     }
 
@@ -85,12 +98,24 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     @Override
     public Iterable<FeedResponse<Receipt>> getFailedReceiptDocuments(String continuationToken, Integer pageSize) {
-        String query = String.format("SELECT * FROM c WHERE (c.status = '%s' or c.status = '%s') AND c.inserted_at >= %s",
-                ReceiptStatusType.FAILED, ReceiptStatusType.NOT_QUEUE_SENT,
-                OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(
-                        Long.parseLong(numDaysRecoverFailed)).toInstant().toEpochMilli());
+        long daysAgo = OffsetDateTime.now()
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverFailed))
+                .toInstant()
+                .toEpochMilli();
 
-        return executePagedQuery(containerId, query, Receipt.class, continuationToken, pageSize);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE (c.status = @statusFailed OR c.status = @statusNotQueueSent) " +
+                        "   AND c.inserted_at >= @minInsertedAt ",
+                Arrays.asList(
+                        new SqlParameter("@statusFailed", ReceiptStatusType.FAILED.name()),
+                        new SqlParameter("@statusNotQueueSent", ReceiptStatusType.NOT_QUEUE_SENT.name()),
+                        new SqlParameter("@minInsertedAt", daysAgo)
+                )
+        );
+
+        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -120,28 +145,57 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      * {@inheritDoc}
      */
     @Override
-    public Iterable<FeedResponse<Receipt>> getGeneratedReceiptDocuments(String continuationToken, Integer pageSize)  {
+    public Iterable<FeedResponse<Receipt>> getGeneratedReceiptDocuments(String continuationToken, Integer pageSize) {
         OffsetDateTime currentDateTime = OffsetDateTime.now();
-        long now = currentDateTime.toInstant().toEpochMilli();
-        long daysAgo = currentDateTime.truncatedTo(ChronoUnit.DAYS).minusDays(Long.parseLong(numDaysRecoverNotNotified)).toInstant().toEpochMilli();
+        long daysAgo = currentDateTime
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverNotNotified))
+                .toInstant()
+                .toEpochMilli();
 
-        String query = String.format("SELECT * FROM c WHERE (c.status = '%s' AND c.generated_at >= %s AND ( %s - c.generated_at) >= %s)",
-                ReceiptStatusType.GENERATED, daysAgo, now, millisNotifyDif);
+        // (now - c.generated_at) >= millisNotifyDif  <=>  c.generated_at <= now - millisNotifyDif
+        long maxGeneratedAt = currentDateTime.toInstant().toEpochMilli() - Long.parseLong(millisNotifyDif);
 
-        return executePagedQuery(containerId, query, Receipt.class, continuationToken, pageSize);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE c.status = @statusGenerated " +
+                        "  AND c.generated_at >= @minGeneratedAt " +
+                        "  AND c.generated_at <= @maxGeneratedAt",
+                Arrays.asList(
+                        new SqlParameter("@statusGenerated", ReceiptStatusType.GENERATED.name()),
+                        new SqlParameter("@minGeneratedAt", daysAgo),
+                        new SqlParameter("@maxGeneratedAt", maxGeneratedAt)
+                )
+        );
+
+        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Iterable<FeedResponse<Receipt>> getIOErrorToNotifyReceiptDocuments(String continuationToken, Integer pageSize)  {
-        long daysAgo = OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(Long.parseLong(numDaysRecoverNotNotified)).toInstant().toEpochMilli();
+    public Iterable<FeedResponse<Receipt>> getIOErrorToNotifyReceiptDocuments(
+            String continuationToken,
+            Integer pageSize
+    ) {
+        long daysAgo = OffsetDateTime.now()
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverNotNotified))
+                .toInstant()
+                .toEpochMilli();
 
-        String query = String.format("SELECT * FROM c WHERE c.status = '%s' AND c.generated_at >= %s",
-                ReceiptStatusType.IO_ERROR_TO_NOTIFY, daysAgo);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE c.status = @statusIoErrorToNotify " +
+                        "  AND c.generated_at >= @generatedAt",
+                Arrays.asList(
+                        new SqlParameter("@statusIoErrorToNotify", ReceiptStatusType.IO_ERROR_TO_NOTIFY.name()),
+                        new SqlParameter("@generatedAt", daysAgo)
+                )
+        );
 
-        return executePagedQuery(containerId, query, Receipt.class, continuationToken, pageSize);
+        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -150,37 +204,54 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     @Override
     public Iterable<FeedResponse<Receipt>> getInsertedReceiptDocuments(String continuationToken, Integer pageSize) {
         OffsetDateTime currentDateTime = OffsetDateTime.now();
-        long now = currentDateTime.toInstant().toEpochMilli();
-        long daysAgo = currentDateTime.truncatedTo(ChronoUnit.DAYS).minusDays(Long.parseLong(numDaysRecoverFailed)).toInstant().toEpochMilli();
+        long daysAgo = currentDateTime
+                .truncatedTo(ChronoUnit.DAYS)
+                .minusDays(Long.parseLong(numDaysRecoverFailed))
+                .toInstant()
+                .toEpochMilli();
 
-        String query = String.format(
-                "SELECT * FROM c WHERE (c.status = '%s' AND c.inserted_at >= %s AND ( %s - c.inserted_at) >= %s)",
-                ReceiptStatusType.INSERTED, daysAgo, now, millisDiff);
+        // (now - c.inserted_at) >= millisDiff  <=>  c.inserted_at <= now - millisDiff
+        long maxInsertedAt = currentDateTime.toInstant().toEpochMilli() - Long.parseLong(millisDiff);
 
-        return executePagedQuery(containerId, query, Receipt.class, continuationToken, pageSize);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c " +
+                        "WHERE c.status = @statusInserted " +
+                        "  AND c.inserted_at >= @minInsertedAt " +
+                        "  AND c.inserted_at <= @maxInsertedAt",
+                Arrays.asList(
+                        new SqlParameter("@statusInserted", ReceiptStatusType.INSERTED.name()),
+                        new SqlParameter("@minInsertedAt", daysAgo),
+                        new SqlParameter("@maxInsertedAt", maxInsertedAt)
+                )
+        );
+
+        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
     }
 
     /**
      * PRIVATE METHODS
      */
 
-    private <T> Optional<T> getDocumentByFilter(String containerId, String propertyName, String propertyValue, Class<T> classType) {
+    private <T> Optional<T> getDocumentByFilter(String containerId, SqlQuerySpec querySpec, Class<T> classType) {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
 
-        String query = String.format("SELECT * FROM c WHERE c.%s = '%s'", propertyName, propertyValue);
-
         // use stream() to convert iterable and find first element
         return cosmosContainer
-                .queryItems(query, new CosmosQueryRequestOptions(), classType)
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), classType)
                 .stream()
                 .findFirst();
     }
 
-    private <T> Iterable<FeedResponse<T>> executePagedQuery(String containerName, String query, Class<T> classType, String continuationToken, Integer pageSize) {
+    private Iterable<FeedResponse<Receipt>> executePagedQuery(
+            String containerName,
+            SqlQuerySpec querySpec,
+            String continuationToken,
+            Integer pageSize
+    ) {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
         return cosmosDatabase.getContainer(containerName)
-                .queryItems(query, new CosmosQueryRequestOptions(), classType)
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), Receipt.class)
                 .iterableByPage(continuationToken, pageSize);
     }
 

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -18,7 +18,6 @@ import it.gov.pagopa.receipt.pdf.datastore.exception.ReceiptNotFoundException;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -135,7 +134,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 "SELECT * FROM c " +
                         "WHERE (c.status = @statusFailed OR c.status = @statusNotQueueSent) " +
                         "   AND c.inserted_at >= @minInsertedAt ",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusFailed", ReceiptStatusType.FAILED.name()),
                         new SqlParameter("@statusNotQueueSent", ReceiptStatusType.NOT_QUEUE_SENT.name()),
                         new SqlParameter("@minInsertedAt", daysAgo)
@@ -181,7 +180,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                         "WHERE c.status = @statusGenerated " +
                         "  AND c.generated_at >= @minGeneratedAt " +
                         "  AND c.generated_at <= @maxGeneratedAt",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusGenerated", ReceiptStatusType.GENERATED.name()),
                         new SqlParameter("@minGeneratedAt", daysAgo),
                         new SqlParameter("@maxGeneratedAt", maxGeneratedAt)
@@ -209,7 +208,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 "SELECT * FROM c " +
                         "WHERE c.status = @statusIoErrorToNotify " +
                         "  AND c.generated_at >= @generatedAt",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusIoErrorToNotify", ReceiptStatusType.IO_ERROR_TO_NOTIFY.name()),
                         new SqlParameter("@generatedAt", daysAgo)
                 )
@@ -238,7 +237,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                         "WHERE c.status = @statusInserted " +
                         "  AND c.inserted_at >= @minInsertedAt " +
                         "  AND c.inserted_at <= @maxInsertedAt",
-                Arrays.asList(
+                List.of(
                         new SqlParameter("@statusInserted", ReceiptStatusType.INSERTED.name()),
                         new SqlParameter("@minInsertedAt", daysAgo),
                         new SqlParameter("@maxInsertedAt", maxInsertedAt)

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -8,9 +8,9 @@ import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.FeedResponse;
+import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
-import com.azure.cosmos.models.PartitionKey;
 import it.gov.pagopa.receipt.pdf.datastore.client.ReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.ReceiptError;
@@ -30,10 +30,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
 
     private static ReceiptCosmosClientImpl instance;
 
-    private final String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
-    private final String containerId = System.getenv("COSMOS_RECEIPT_CONTAINER_NAME");
-    private final String containerReceiptErrorId = System.getenv().getOrDefault("COSMOS_RECEIPT_ERROR_CONTAINER_NAME", "receipts-message-errors");
-
     private static final String DOCUMENT_NOT_FOUND_ERR_MSG = "Document not found in the defined container";
 
     private final String millisDiff = System.getenv().getOrDefault("MAX_DATE_DIFF_MILLIS", "1800000");
@@ -42,6 +38,8 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     private final String numDaysRecoverNotNotified = System.getenv().getOrDefault("RECOVER_NOT_NOTIFIED_MASSIVE_MAX_DAYS", "0");
 
     private final CosmosClient cosmosClient;
+    private final CosmosContainer receiptContainer;
+    private final CosmosContainer receiptErrorContainer;
 
     private ReceiptCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_RECEIPT_KEY");
@@ -53,10 +51,29 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 .key(azureKey)
                 .preferredRegions(List.of(readRegion))
                 .buildClient();
+
+        String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
+        String containerId = System.getenv("COSMOS_RECEIPT_CONTAINER_NAME");
+        String containerReceiptErrorId = System.getenv()
+                .getOrDefault("COSMOS_RECEIPT_ERROR_CONTAINER_NAME", "receipts-message-errors");
+
+        CosmosDatabase database = this.cosmosClient.getDatabase(databaseId);
+        this.receiptContainer = database.getContainer(containerId);
+        this.receiptErrorContainer = database.getContainer(containerReceiptErrorId);
     }
 
-    public ReceiptCosmosClientImpl(CosmosClient cosmosClient) {
+    /**
+     * Test-only constructor. Package-private visibility so it is only reachable from tests
+     * in the same package.
+     */
+    ReceiptCosmosClientImpl(
+            CosmosClient cosmosClient,
+            CosmosContainer receiptContainer,
+            CosmosContainer receiptErrorContainer
+    ) {
         this.cosmosClient = cosmosClient;
+        this.receiptContainer = receiptContainer;
+        this.receiptErrorContainer = receiptErrorContainer;
     }
 
     public static ReceiptCosmosClientImpl getInstance() {
@@ -72,11 +89,8 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     @Override
     public Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
         try {
-            return cosmosContainer.readItem(eventId, new PartitionKey(eventId), Receipt.class)
+            return receiptContainer.readItem(eventId, new PartitionKey(eventId), Receipt.class)
                     .getItem();
         } catch (CosmosException e) {
             if (e.getStatusCode() != 404) {
@@ -88,7 +102,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                     List.of(new SqlParameter("@eventId", eventId))
             );
 
-            return getDocumentByFilter(containerId, querySpec, Receipt.class)
+            return getDocumentByFilter(receiptContainer, querySpec, Receipt.class)
                     .orElseThrow(() -> new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG));
         }
     }
@@ -103,7 +117,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 List.of(new SqlParameter("@bizEventId", bizEventId))
         );
 
-        return getDocumentByFilter(containerReceiptErrorId, querySpec, ReceiptError.class)
+        return getDocumentByFilter(receiptErrorContainer, querySpec, ReceiptError.class)
                 .orElseThrow(() -> new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG));
     }
 
@@ -129,7 +143,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 )
         );
 
-        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -137,11 +151,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     @Override
     public CosmosItemResponse<Receipt> saveReceipts(Receipt receipt) {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
-        return cosmosContainer.createItem(receipt);
+        return receiptContainer.createItem(receipt);
     }
 
     /**
@@ -149,10 +159,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     @Override
     public CosmosItemResponse<Receipt> updateReceipts(Receipt receipt) {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
-        return cosmosContainer.upsertItem(receipt);
+        return receiptContainer.upsertItem(receipt);
     }
 
     /**
@@ -182,7 +189,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 )
         );
 
-        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -209,7 +216,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 )
         );
 
-        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     /**
@@ -239,32 +246,27 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 )
         );
 
-        return executePagedQuery(containerId, querySpec, continuationToken, pageSize);
+        return executePagedQuery(querySpec, continuationToken, pageSize);
     }
 
     /**
      * PRIVATE METHODS
      */
 
-    private <T> Optional<T> getDocumentByFilter(String containerId, SqlQuerySpec querySpec, Class<T> classType) {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
+    private <T> Optional<T> getDocumentByFilter(CosmosContainer container, SqlQuerySpec querySpec, Class<T> classType) {
         // use stream() to convert iterable and find first element
-        return cosmosContainer
+        return container
                 .queryItems(querySpec, new CosmosQueryRequestOptions(), classType)
                 .stream()
                 .findFirst();
     }
 
     private Iterable<FeedResponse<Receipt>> executePagedQuery(
-            String containerName,
             SqlQuerySpec querySpec,
             String continuationToken,
             Integer pageSize
     ) {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        return cosmosDatabase.getContainer(containerName)
+        return receiptContainer
                 .queryItems(querySpec, new CosmosQueryRequestOptions(), Receipt.class)
                 .iterableByPage(continuationToken, pageSize);
     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImpl.java
@@ -93,17 +93,17 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                     .getItem();
         } catch (CosmosException e) {
             if (e.getStatusCode() != 404) {
-                throw new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG, e);
+                throw e;
             }
-            // if not found use fallback query
-            SqlQuerySpec querySpec = new SqlQuerySpec(
-                    "SELECT * FROM c WHERE c.eventId = @eventId",
-                    List.of(new SqlParameter("@eventId", eventId))
-            );
-
-            return getDocumentByFilter(receiptContainer, querySpec, Receipt.class)
-                    .orElseThrow(() -> new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG));
         }
+        // if not found use fallback query
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c WHERE c.eventId = @eventId",
+                List.of(new SqlParameter("@eventId", eventId))
+        );
+
+        return getDocumentByFilter(receiptContainer, querySpec, Receipt.class)
+                .orElseThrow(() -> new ReceiptNotFoundException(DOCUMENT_NOT_FOUND_ERR_MSG));
     }
 
     /**
@@ -269,5 +269,4 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                 .queryItems(querySpec, new CosmosQueryRequestOptions(), Receipt.class)
                 .iterableByPage(continuationToken, pageSize);
     }
-
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptQueueClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptQueueClientImpl.java
@@ -14,8 +14,6 @@ import java.time.temporal.ChronoUnit;
  */
 public class ReceiptQueueClientImpl implements ReceiptQueueClient {
 
-    private static ReceiptQueueClientImpl instance;
-
     private final int receiptQueueDelay = Integer.parseInt(System.getenv().getOrDefault("RECEIPT_QUEUE_DELAY", "1"));
 
     private final QueueClient queueClient;
@@ -35,11 +33,15 @@ public class ReceiptQueueClientImpl implements ReceiptQueueClient {
     }
 
     public static ReceiptQueueClientImpl getInstance() {
-        if (instance == null) {
-            instance = new ReceiptQueueClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final ReceiptQueueClientImpl INSTANCE = new ReceiptQueueClientImpl();
     }
 
     /**

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
@@ -46,6 +46,7 @@ class BizEventCosmosClientImplTest {
     @InjectMocks
     private BizEventCosmosClientImpl sut;
 
+
     @Test
     void testSingletonConnectionError() throws Exception {
         String mockKey = "mockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeyMK==";
@@ -58,8 +59,6 @@ class BizEventCosmosClientImplTest {
 
     @Test
     void getAllCartBizEventDocumentsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(BizEvent.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(Stream.of(new BizEvent()));
 
@@ -71,8 +70,6 @@ class BizEventCosmosClientImplTest {
 
     @Test
     void getAllCartBizEventDocumentsSuccessQueryResultTruncated() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(BizEvent.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(Stream.of(new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent()));
 
@@ -84,8 +81,6 @@ class BizEventCosmosClientImplTest {
 
     @Test
     void getBizEventDocumentSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(anyString(), any(), eq(BizEvent.class))).thenReturn(mockResponse);
         when(mockResponse.getItem()).thenReturn(new BizEvent());
 
@@ -94,8 +89,6 @@ class BizEventCosmosClientImplTest {
 
     @Test
     void getBizEventDocumentError() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(anyString(), any(), eq(BizEvent.class))).thenThrow(CosmosException.class);
 
         assertThrows(BizEventNotFoundException.class, () -> sut.getBizEventDocument("1"));

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
@@ -35,6 +35,8 @@ class BizEventCosmosClientImplTest {
     private CosmosPagedIterable<BizEvent> mockIterable;
     @Mock
     private CosmosItemResponse<BizEvent> mockResponse;
+    @Mock
+    private CosmosException mockCosmosException;
 
     @InjectMocks
     private BizEventCosmosClientImpl sut;
@@ -81,9 +83,18 @@ class BizEventCosmosClientImplTest {
     }
 
     @Test
-    void getBizEventDocumentError() {
-        when(mockContainer.readItem(anyString(), any(), eq(BizEvent.class))).thenThrow(CosmosException.class);
+    void getBizEventDocument_KO_notFound() {
+        when(mockCosmosException.getStatusCode()).thenReturn(404);
+        when(mockContainer.readItem(anyString(), any(), eq(BizEvent.class))).thenThrow(mockCosmosException);
 
         assertThrows(BizEventNotFoundException.class, () -> sut.getBizEventDocument("1"));
+    }
+
+    @Test
+    void getBizEventDocument_KO() {
+        when(mockCosmosException.getStatusCode()).thenReturn(500);
+        when(mockContainer.readItem(anyString(), any(), eq(BizEvent.class))).thenThrow(mockCosmosException);
+
+        assertThrows(CosmosException.class, () -> sut.getBizEventDocument("1"));
     }
 }

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
@@ -5,6 +5,7 @@ import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosItemResponse;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.datastore.entity.event.BizEvent;
 import it.gov.pagopa.receipt.pdf.datastore.exception.BizEventNotFoundException;
@@ -59,7 +60,7 @@ class BizEventCosmosClientImplTest {
     void getAllCartBizEventDocumentsSuccess() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(BizEvent.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(BizEvent.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(Stream.of(new BizEvent()));
 
         List<BizEvent> result = assertDoesNotThrow(() -> sut.getAllCartBizEventDocument(""));
@@ -72,7 +73,7 @@ class BizEventCosmosClientImplTest {
     void getAllCartBizEventDocumentsSuccessQueryResultTruncated() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(BizEvent.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(BizEvent.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(Stream.of(new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent(), new BizEvent()));
 
         List<BizEvent> result = assertDoesNotThrow(() -> sut.getAllCartBizEventDocument(""));

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
@@ -1,8 +1,6 @@
 package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.SqlQuerySpec;
@@ -31,11 +29,6 @@ import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables
 @ExtendWith(MockitoExtension.class)
 class BizEventCosmosClientImplTest {
 
-    @Mock
-    private CosmosClient cosmosClientMock;
-
-    @Mock
-    private CosmosDatabase mockDatabase;
     @Mock
     private CosmosContainer mockContainer;
     @Mock

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/BizEventCosmosClientImplTest.java
@@ -54,7 +54,7 @@ class BizEventCosmosClientImplTest {
                 "COSMOS_BIZ_EVENT_KEY", mockKey,
                 "COSMOS_BIZ_EVENT_SERVICE_ENDPOINT", "",
                 "COSMOS_BIZ_EVENT_READ_REGION", "")
-                .execute(() -> assertThrows(IllegalArgumentException.class, BizEventCosmosClientImpl::getInstance));
+                .execute(() -> assertThrows(ExceptionInInitializerError.class, BizEventCosmosClientImpl::getInstance));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
@@ -42,6 +42,8 @@ class CartReceiptsCosmosClientImplTest {
     private CosmosItemResponse<CartForReceipt> mockReceiptResponse;
     @Mock
     private CosmosItemResponse<CartReceiptError> mockReceiptErrorResponse;
+    @Mock
+    private CosmosException mockCosmosException;
 
     @InjectMocks
     private CartReceiptsCosmosClientImpl sut;
@@ -71,10 +73,19 @@ class CartReceiptsCosmosClientImplTest {
     }
 
     @Test
-    void getCartItemFail() {
-        when(mockContainer.readItem(anyString(), any(), eq(CartForReceipt.class))).thenThrow(CosmosException.class);
+    void getCartItem_KO_notFound() {
+        when(mockCosmosException.getStatusCode()).thenReturn(404);
+        when(mockContainer.readItem(anyString(), any(), eq(CartForReceipt.class))).thenThrow(mockCosmosException);
 
         assertThrows(CartNotFoundException.class, () -> sut.getCartItem("an invalid receipt id"));
+    }
+
+    @Test
+    void getCartItem_KO() {
+        when(mockCosmosException.getStatusCode()).thenReturn(500);
+        when(mockContainer.readItem(anyString(), any(), eq(CartForReceipt.class))).thenThrow(mockCosmosException);
+
+        assertThrows(CosmosException.class, () -> sut.getCartItem("an invalid receipt id"));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
@@ -60,9 +60,8 @@ class CartReceiptsCosmosClientImplTest {
         withEnvironmentVariables(
                 "COSMOS_RECEIPT_KEY", mockKey,
                 "COSMOS_RECEIPT_SERVICE_ENDPOINT", "",
-                "COSMOS_RECEIPT_READ_REGION", ""
-        ).execute(() -> assertThrows(IllegalArgumentException.class, CartReceiptsCosmosClientImpl::getInstance)
-        );
+                "COSMOS_RECEIPT_READ_REGION", "")
+                .execute(() -> assertThrows(ExceptionInInitializerError.class, CartReceiptsCosmosClientImpl::getInstance));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
@@ -6,6 +6,7 @@ import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.FeedResponse;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.datastore.entity.cart.CartForReceipt;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.CartReceiptError;
@@ -117,7 +118,7 @@ class CartReceiptsCosmosClientImplTest {
     void getFailedCartReceiptDocumentsSuccess() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartForReceipt.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
 
@@ -131,7 +132,7 @@ class CartReceiptsCosmosClientImplTest {
     void getInsertedCartReceiptDocumentsSuccess() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartForReceipt.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
 
@@ -145,7 +146,7 @@ class CartReceiptsCosmosClientImplTest {
     void getIOErrorToNotifyCartReceiptDocumentsSuccess() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartForReceipt.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
 
@@ -159,7 +160,7 @@ class CartReceiptsCosmosClientImplTest {
     void getGeneratedCartReceiptDocumentsSuccess() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartForReceipt.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
 

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
@@ -1,8 +1,6 @@
 package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.FeedResponse;
@@ -34,11 +32,6 @@ class CartReceiptsCosmosClientImplTest {
 
     private static final String CART_ID = "1";
 
-    @Mock
-    private CosmosClient cosmosClientMock;
-
-    @Mock
-    private CosmosDatabase mockDatabase;
     @Mock
     private CosmosContainer mockContainer;
     @Mock

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/CartReceiptsCosmosClientImplTest.java
@@ -53,6 +53,7 @@ class CartReceiptsCosmosClientImplTest {
     @InjectMocks
     private CartReceiptsCosmosClientImpl sut;
 
+
     @Test
     void testSingletonConnectionError() throws Exception {
         String mockKey = "mockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeyMK==";
@@ -69,8 +70,6 @@ class CartReceiptsCosmosClientImplTest {
         CartForReceipt cartForReceipt = new CartForReceipt();
         cartForReceipt.setId(CART_ID);
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(anyString(), any(), eq(CartForReceipt.class))).thenReturn(mockReceiptResponse);
         when(mockReceiptResponse.getItem()).thenReturn(cartForReceipt);
 
@@ -81,8 +80,6 @@ class CartReceiptsCosmosClientImplTest {
 
     @Test
     void getCartItemFail() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(anyString(), any(), eq(CartForReceipt.class))).thenThrow(CosmosException.class);
 
         assertThrows(CartNotFoundException.class, () -> sut.getCartItem("an invalid receipt id"));
@@ -90,9 +87,6 @@ class CartReceiptsCosmosClientImplTest {
 
     @Test
     void updateCartSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-
         assertDoesNotThrow(() -> sut.updateCart(new CartForReceipt()));
 
         verify(mockContainer).upsertItem(any(), any());
@@ -103,10 +97,7 @@ class CartReceiptsCosmosClientImplTest {
         CartReceiptError receiptError = new CartReceiptError();
         receiptError.setId(CART_ID);
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(anyString(), any(), eq(CartReceiptError.class))).thenReturn(mockReceiptErrorResponse);
-        when(mockReceiptErrorResponse.getStatusCode()).thenReturn(200);
         when(mockReceiptErrorResponse.getItem()).thenReturn(receiptError);
 
         CartReceiptError result = assertDoesNotThrow(() -> sut.getCartReceiptError(CART_ID));
@@ -116,8 +107,6 @@ class CartReceiptsCosmosClientImplTest {
 
     @Test
     void getFailedCartReceiptDocumentsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
@@ -130,8 +119,6 @@ class CartReceiptsCosmosClientImplTest {
 
     @Test
     void getInsertedCartReceiptDocumentsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
@@ -144,8 +131,6 @@ class CartReceiptsCosmosClientImplTest {
 
     @Test
     void getIOErrorToNotifyCartReceiptDocumentsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);
@@ -158,8 +143,6 @@ class CartReceiptsCosmosClientImplTest {
 
     @Test
     void getGeneratedCartReceiptDocumentsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartForReceipt.class)))
                 .thenReturn(mockCartIterable);
         when(mockCartIterable.iterableByPage(anyString(), anyInt())).thenReturn(mockCartIterableByPage);

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
@@ -63,6 +63,7 @@ class ReceiptCosmosClientImplTest {
     @InjectMocks
     private ReceiptCosmosClientImpl sut;
 
+
     @Test
     void testSingletonConnectionError() throws Exception {
         String mockKey = "mockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeymockKeyMK==";
@@ -79,8 +80,6 @@ class ReceiptCosmosClientImplTest {
         Receipt receipt = new Receipt();
         receipt.setId(RECEIPT_ID);
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenReturn(mockReceiptResponse);
         when(mockReceiptResponse.getItem()).thenReturn(receipt);
 
@@ -99,8 +98,6 @@ class ReceiptCosmosClientImplTest {
         CosmosException notFound = mock(CosmosException.class);
         when(notFound.getStatusCode()).thenReturn(404);
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(notFound);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
@@ -113,8 +110,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void getReceiptDocument_KO() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(CosmosException.class);
 
         assertThrows(ReceiptNotFoundException.class, () -> sut.getReceiptDocument("an invalid receipt id"));
@@ -127,8 +122,6 @@ class ReceiptCosmosClientImplTest {
         CosmosException notFound = mock(CosmosException.class);
         when(notFound.getStatusCode()).thenReturn(404);
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(notFound);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
@@ -142,8 +135,6 @@ class ReceiptCosmosClientImplTest {
         ReceiptError receiptError = new ReceiptError();
         receiptError.setId(RECEIPT_ID);
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(ReceiptError.class))).thenReturn(mockReceiptErrorIterable);
         when(mockReceiptErrorIterable.stream()).thenReturn(mockReceiptErrorStream);
         when(mockReceiptErrorStream.findFirst()).thenReturn(Optional.of(receiptError));
@@ -155,9 +146,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void saveReceiptsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-
         assertDoesNotThrow(() -> sut.saveReceipts(new Receipt()));
 
         verify(mockContainer).createItem(any());
@@ -165,9 +153,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void updateReceiptsSuccess() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-
         assertDoesNotThrow(() -> sut.updateReceipts(new Receipt()));
 
         verify(mockContainer).upsertItem(any());
@@ -175,8 +160,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void runOk_FailedQueryClient() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
@@ -188,8 +171,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void getGeneratedReceiptDocuments_Success() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
@@ -201,8 +182,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void getIOErrorToNotifyReceiptDocuments_Success() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
@@ -214,8 +193,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void getInsertedReceiptDocuments_Success() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
@@ -1,8 +1,6 @@
 package it.gov.pagopa.receipt.pdf.datastore.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.FeedResponse;
@@ -38,10 +36,6 @@ class ReceiptCosmosClientImplTest {
     public static final String RECEIPT_ID = "a valid receipt id";
     public static final String IO_MESSAGE_ID = "id";
 
-    @Mock
-    private CosmosClient cosmosClientMock;
-    @Mock
-    private CosmosDatabase mockDatabase;
     @Mock
     private CosmosContainer mockContainer;
     @Mock

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,7 +50,7 @@ class ReceiptCosmosClientImplTest {
     @Mock
     private Stream<ReceiptError> mockReceiptErrorStream;
     @Mock
-    private CosmosItemResponse<Receipt> mockCosmosItemResponse;
+    private CosmosException mockCosmosException;
 
     @InjectMocks
     private ReceiptCosmosClientImpl sut;
@@ -87,10 +86,8 @@ class ReceiptCosmosClientImplTest {
         Receipt receipt = new Receipt();
         receipt.setId(RECEIPT_ID);
 
-        CosmosException notFound = mock(CosmosException.class);
-        when(notFound.getStatusCode()).thenReturn(404);
-
-        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(notFound);
+        when(mockCosmosException.getStatusCode()).thenReturn(404);
+        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(mockCosmosException);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
         when(mockReceiptStream.findFirst()).thenReturn(Optional.of(receipt));
@@ -104,17 +101,15 @@ class ReceiptCosmosClientImplTest {
     void getReceiptDocument_KO() {
         when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(CosmosException.class);
 
-        assertThrows(ReceiptNotFoundException.class, () -> sut.getReceiptDocument("an invalid receipt id"));
+        assertThrows(CosmosException.class, () -> sut.getReceiptDocument("an invalid receipt id"));
 
         verify(mockContainer, never()).queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class));
     }
 
     @Test
     void getReceiptDocument_KO_notFountOnBothQuery() {
-        CosmosException notFound = mock(CosmosException.class);
-        when(notFound.getStatusCode()).thenReturn(404);
-
-        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(notFound);
+        when(mockCosmosException.getStatusCode()).thenReturn(404);
+        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(mockCosmosException);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
         when(mockReceiptStream.findFirst()).thenReturn(Optional.empty());

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
@@ -11,7 +11,6 @@ import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.ReceiptError;
 import it.gov.pagopa.receipt.pdf.datastore.exception.ReceiptNotFoundException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -70,9 +69,8 @@ class ReceiptCosmosClientImplTest {
         withEnvironmentVariables(
                 "COSMOS_RECEIPT_KEY", mockKey,
                 "COSMOS_RECEIPT_SERVICE_ENDPOINT", "",
-                "COSMOS_RECEIPT_READ_REGION", ""
-        ).execute(() -> Assertions.assertThrows(IllegalArgumentException.class, ReceiptCosmosClientImpl::getInstance)
-        );
+                "COSMOS_RECEIPT_READ_REGION", "")
+                .execute(() -> assertThrows(ExceptionInInitializerError.class, ReceiptCosmosClientImpl::getInstance));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
@@ -4,6 +4,7 @@ import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.FeedResponse;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.ReceiptError;
@@ -23,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,7 +73,7 @@ class ReceiptCosmosClientImplTest {
 
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
         when(mockReceiptStream.findFirst()).thenReturn(Optional.of(receipt));
 
@@ -86,7 +86,7 @@ class ReceiptCosmosClientImplTest {
     void getReceiptDocumentKo() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
         when(mockReceiptStream.findFirst()).thenReturn(Optional.empty());
 
@@ -100,7 +100,7 @@ class ReceiptCosmosClientImplTest {
 
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(ReceiptError.class))).thenReturn(mockReceiptErrorIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(ReceiptError.class))).thenReturn(mockReceiptErrorIterable);
         when(mockReceiptErrorIterable.stream()).thenReturn(mockReceiptErrorStream);
         when(mockReceiptErrorStream.findFirst()).thenReturn(Optional.of(receiptError));
 
@@ -133,7 +133,7 @@ class ReceiptCosmosClientImplTest {
     void runOk_FailedQueryClient() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
         Iterable<FeedResponse<Receipt>> result =
@@ -146,7 +146,7 @@ class ReceiptCosmosClientImplTest {
     void getGeneratedReceiptDocuments_Success() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
         Iterable<FeedResponse<Receipt>> result =
@@ -159,7 +159,7 @@ class ReceiptCosmosClientImplTest {
     void getIOErrorToNotifyReceiptDocuments_Success() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
         Iterable<FeedResponse<Receipt>> result =
@@ -172,7 +172,7 @@ class ReceiptCosmosClientImplTest {
     void getInsertedReceiptDocuments_Success() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.iterableByPage(null, 1)).thenReturn(mockReceiptIterableByPage);
 
         Iterable<FeedResponse<Receipt>> result =

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/client/impl/ReceiptCosmosClientImplTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
@@ -46,6 +47,8 @@ class ReceiptCosmosClientImplTest {
     private CosmosContainer mockContainer;
     @Mock
     private CosmosPagedIterable<Receipt> mockIterable;
+    @Mock
+    private CosmosItemResponse<Receipt> mockReceiptResponse;
     @Mock
     private CosmosPagedIterable<ReceiptError> mockReceiptErrorIterable;
     @Mock
@@ -72,12 +75,33 @@ class ReceiptCosmosClientImplTest {
     }
 
     @Test
-    void getReceiptDocumentOk() {
+    void getReceiptDocument_OK_pointRead() {
         Receipt receipt = new Receipt();
         receipt.setId(RECEIPT_ID);
 
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
+        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenReturn(mockReceiptResponse);
+        when(mockReceiptResponse.getItem()).thenReturn(receipt);
+
+        Receipt result = assertDoesNotThrow(() -> sut.getReceiptDocument(RECEIPT_ID));
+
+        assertEquals(RECEIPT_ID, result.getId());
+
+        verify(mockContainer, never()).queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class));
+    }
+
+    @Test
+    void getReceiptDocument_OK_fallbackOnIterate() {
+        Receipt receipt = new Receipt();
+        receipt.setId(RECEIPT_ID);
+
+        CosmosException notFound = mock(CosmosException.class);
+        when(notFound.getStatusCode()).thenReturn(404);
+
+        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
+        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
+        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(notFound);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
         when(mockReceiptStream.findFirst()).thenReturn(Optional.of(receipt));
@@ -88,9 +112,24 @@ class ReceiptCosmosClientImplTest {
     }
 
     @Test
-    void getReceiptDocumentKo() {
+    void getReceiptDocument_KO() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
+        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(CosmosException.class);
+
+        assertThrows(ReceiptNotFoundException.class, () -> sut.getReceiptDocument("an invalid receipt id"));
+
+        verify(mockContainer, never()).queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class));
+    }
+
+    @Test
+    void getReceiptDocument_KO_notFountOnBothQuery() {
+        CosmosException notFound = mock(CosmosException.class);
+        when(notFound.getStatusCode()).thenReturn(404);
+
+        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
+        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
+        when(mockContainer.readItem(any(), any(), eq(Receipt.class))).thenThrow(notFound);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
         when(mockIterable.stream()).thenReturn(mockReceiptStream);
         when(mockReceiptStream.findFirst()).thenReturn(Optional.empty());
@@ -184,34 +223,5 @@ class ReceiptCosmosClientImplTest {
                 assertDoesNotThrow(() -> sut.getInsertedReceiptDocuments(null, 1));
 
         assertNotNull(result);
-    }
-
-    @Test
-    void getReceiptDocument_SuccessWithReadItem() {
-        Receipt receipt = new Receipt();
-        receipt.setId(RECEIPT_ID);
-
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.readItem(eq(RECEIPT_ID), any(), eq(Receipt.class)))
-                .thenReturn(mockCosmosItemResponse);
-        when(mockCosmosItemResponse.getItem()).thenReturn(receipt);
-
-        Receipt result = assertDoesNotThrow(() -> sut.getReceiptDocument(RECEIPT_ID));
-
-        assertEquals(RECEIPT_ID, result.getId());
-    }
-
-    @Test
-    void getReceiptDocument_CosmosExceptionNon404() {
-        CosmosException cosmosException = mock(CosmosException.class);
-        when(cosmosException.getStatusCode()).thenReturn(500);
-
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.readItem(eq(RECEIPT_ID), any(), eq(Receipt.class)))
-                .thenThrow(cosmosException);
-
-        assertThrows(CosmosException.class, () -> sut.getReceiptDocument(RECEIPT_ID));
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- build cosmos query with `SqlQuerySpec` instead of `String.format()`
- refactor CosmosClient in order to resolve CosmosContainer once in the constructor
- replaced the non-thread-safe lazy initialization in all clients with the **Bill Pugh singleton holder** pattern
- Suppressed the legitimate but intentional `resource` warning on the private constructors (`CosmosClient` lifecycle is bound to the singleton).
- updated unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
[PAGOPA-3625](https://pagopa.atlassian.net/browse/PAGOPA-3625)
[PAGOPA-3667](https://pagopa.atlassian.net/browse/PAGOPA-3667)
<!--- Why is this change required? What problem does it solve? -->
- Allow Cosmos to leverage **query plan caching** by building query with `SqlQuerySpec`.
- The original clients re-resolved `CosmosDatabase` and `CosmosContainer` on every operation, duplicating boilerplate code going against the [official best practices for the Cosmos DB Java SDK v4](https://learn.microsoft.com/azure/cosmos-db/nosql/best-practice-java) (client and container references should be singletons for the whole application lifetime).
- The classic lazy singleton (`if (instance == null) instance = new ...`) is **not thread-safe**: under concurrent load an Azure Functions worker could build multiple Cosmos clients, each with its own TCP connection pool, wasting resources and potentially exceeding SNAT limits. The Bill Pugh holder pattern is thread-safe by JLS §12.4.2 guarantees, lazy, and has zero synchronization overhead on subsequent calls.
- Catching the `com.azure.cosmos.implementation.NotFoundException` from an SDK-internal package is unstable across SDK versions.
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[PAGOPA-3625]: https://pagopa.atlassian.net/browse/PAGOPA-3625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PAGOPA-3667]: https://pagopa.atlassian.net/browse/PAGOPA-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ