### PR TITLE
[PIDM-862] notify app io

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfdatastore
 description: Microservice description
 type: application
-version: 0.165.0
-appVersion: 1.17.11
+version: 0.166.0
+appVersion: 1.17.12-PIDM-862-notify-appIO
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.11"
+    tag: "1.17.12-PIDM-862-notify-appIO"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.11"
+    tag: "1.17.12-PIDM-862-notify-appIO"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: "pagopa-receipt-pdf-datastore"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-datastore
-    tag: "1.17.11"
+    tag: "1.17.12-PIDM-862-notify-appIO"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "Receipts Datastore Helpdesk",
     "description": "Microservice for exposing REST APIs about receipts datastore helpdesk.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.17.11"
+    "version": "1.17.12-PIDM-862-notify-appIO"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.receipt</groupId>
     <artifactId>receipt-pdf-datastore</artifactId>
-    <version>1.17.11</version>
+    <version>1.17.12-PIDM-862-notify-appIO</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-datastore</name>

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/entity/receipt/Receipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/entity/receipt/Receipt.java
@@ -27,4 +27,5 @@ public class Receipt {
     private long inserted_at;
     private long generated_at;
     private long notified_at;
+    private Boolean sendNotification;
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceipt.java
@@ -118,9 +118,12 @@ public class RecoverFailedReceipt {
             return buildErrorResponse(request, HttpStatus.UNPROCESSABLE_ENTITY, errMsg);
         }
 
+        boolean sendNotification = Boolean.parseBoolean(request.getQueryParameters().getOrDefault(
+            "sendNotification", "true"));
+
         Receipt receipt;
         try {
-            receipt = this.helpdeskService.recoverFailedReceipt(existingReceipt);
+            receipt = this.helpdeskService.recoverFailedReceipt(existingReceipt, sendNotification);
         } catch (BizEventUnprocessableEntityException e) {
             logger.warn(e.getMessage(), e);
             return buildErrorResponse(request, HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceiptMassive.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceiptMassive.java
@@ -93,7 +93,10 @@ public class RecoverFailedReceiptMassive {
             return buildErrorResponse(request, HttpStatus.UNPROCESSABLE_ENTITY, message);
         }
 
-        MassiveRecoverResult recoverResult = this.helpdeskService.massiveRecoverFailedReceipt(status);
+        boolean sendNotification = Boolean.parseBoolean(request.getQueryParameters().getOrDefault(
+            "sendNotification", "true"));
+
+        MassiveRecoverResult recoverResult = this.helpdeskService.massiveRecoverFailedReceipt(status, sendNotification);
 
         int successCounter = recoverResult.getSuccessCounter();
         int errorCounter = recoverResult.getErrorCounter();

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/schedule/RecoverFailedReceiptScheduled.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/schedule/RecoverFailedReceiptScheduled.java
@@ -73,7 +73,7 @@ public class RecoverFailedReceiptScheduled {
     }
 
     private List<Receipt> recover(ReceiptStatusType status) {
-        MassiveRecoverResult recoverResult = this.helpdeskService.massiveRecoverFailedReceipt(status);
+        MassiveRecoverResult recoverResult = this.helpdeskService.massiveRecoverFailedReceipt(status, true);
 
         int successCounter = recoverResult.getSuccessCounter();
         int errorCounter = recoverResult.getErrorCounter();

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/service/HelpdeskService.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/service/HelpdeskService.java
@@ -30,7 +30,7 @@ public interface HelpdeskService {
      * @throws BizEventBadRequestException          in case the biz event is invalid for receipt generation
      * @throws BizEventNotFoundException            in case no biz event is found for the specified receipt
      */
-    Receipt recoverFailedReceipt(Receipt existingReceipt)
+    Receipt recoverFailedReceipt(Receipt existingReceipt, Boolean sendNotification)
             throws BizEventUnprocessableEntityException, BizEventBadRequestException, BizEventNotFoundException;
 
     /**
@@ -74,7 +74,7 @@ public interface HelpdeskService {
      * @param status the status to be recovered
      * @return the recover result
      */
-    MassiveRecoverResult massiveRecoverFailedReceipt(ReceiptStatusType status);
+    MassiveRecoverResult massiveRecoverFailedReceipt(ReceiptStatusType status, Boolean sendNotification);
 
     /**
      * Massive recover all failed cart with the specified status {@link CartStatusType}

--- a/src/main/java/it/gov/pagopa/receipt/pdf/datastore/service/impl/HelpdeskServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/datastore/service/impl/HelpdeskServiceImpl.java
@@ -62,7 +62,7 @@ public class HelpdeskServiceImpl implements HelpdeskService {
     }
 
     @Override
-    public Receipt recoverFailedReceipt(Receipt existingReceipt)
+    public Receipt recoverFailedReceipt(Receipt existingReceipt, Boolean sendNotification)
             throws BizEventUnprocessableEntityException, BizEventBadRequestException, BizEventNotFoundException {
         // retrieve biz-event with the specified cartId
 
@@ -72,6 +72,7 @@ public class HelpdeskServiceImpl implements HelpdeskService {
         Receipt receipt = createReceipt(bizEvent, bizEventToReceiptService, logger);
         // override generated id to avoid receipt duplication
         receipt.setId(existingReceipt.getId());
+        receipt.setSendNotification(sendNotification);
 
         if (isReceiptStatusValid(receipt)) {
             receipt.setStatus(ReceiptStatusType.INSERTED);
@@ -135,7 +136,7 @@ public class HelpdeskServiceImpl implements HelpdeskService {
     }
 
     @Override
-    public MassiveRecoverResult massiveRecoverFailedReceipt(ReceiptStatusType status) {
+    public MassiveRecoverResult massiveRecoverFailedReceipt(ReceiptStatusType status, Boolean sendNotification) {
         List<Receipt> failedReceipts = new ArrayList<>();
         int successCounter = 0;
         int errorCounter = 0;
@@ -151,7 +152,7 @@ public class HelpdeskServiceImpl implements HelpdeskService {
                 }
 
                 try {
-                    Receipt restored = recoverFailedReceipt(receipt);
+                    Receipt restored = recoverFailedReceipt(receipt, sendNotification);
 
                     if (isReceiptStatusValid(restored)) {
                         successCounter++;

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceiptMassiveTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceiptMassiveTest.java
@@ -10,6 +10,7 @@ import it.gov.pagopa.receipt.pdf.datastore.entity.receipt.enumeration.ReceiptSta
 import it.gov.pagopa.receipt.pdf.datastore.model.MassiveRecoverResult;
 import it.gov.pagopa.receipt.pdf.datastore.service.HelpdeskService;
 import it.gov.pagopa.receipt.pdf.datastore.utils.HttpResponseMessageMock;
+import java.util.HashMap;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -70,7 +73,7 @@ class RecoverFailedReceiptMassiveTest {
     @SneakyThrows
     void recoverFailedReceiptMassiveSuccess(ReceiptStatusType status) {
         doReturn(Collections.singletonMap("status", status.name())).when(requestMock).getQueryParameters();
-        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, documentdb, contextMock));
@@ -94,7 +97,7 @@ class RecoverFailedReceiptMassiveTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
         assertNotNull(response.getBody());
 
-        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class),  anyBoolean());
         verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 
@@ -111,7 +114,7 @@ class RecoverFailedReceiptMassiveTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
         assertNotNull(response.getBody());
 
-        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), anyBoolean());
         verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 
@@ -129,7 +132,7 @@ class RecoverFailedReceiptMassiveTest {
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatus());
         assertNotNull(response.getBody());
 
-        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), anyBoolean());
         verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 
@@ -143,7 +146,7 @@ class RecoverFailedReceiptMassiveTest {
                 .build();
 
         doReturn(Collections.singletonMap("status", ReceiptStatusType.FAILED.name())).when(requestMock).getQueryParameters();
-        doReturn(recoverResult).when(helpdeskServiceMock).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        doReturn(recoverResult).when(helpdeskServiceMock).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, documentdb, contextMock));
@@ -155,5 +158,44 @@ class RecoverFailedReceiptMassiveTest {
 
         verify(documentdb).setValue(receiptCaptor.capture());
         assertNotNull(receiptCaptor.getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    void recoverFailedReceiptMassiveWithSendNotificationFalse() {
+        HashMap<String, String> queryParams = new HashMap<>();
+        queryParams.put("status", ReceiptStatusType.FAILED.name());
+        queryParams.put("sendNotification", "false");
+        doReturn(queryParams).when(requestMock).getQueryParameters();
+        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), eq(false));
+
+        // test execution
+        HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, documentdb, contextMock));
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(helpdeskServiceMock).massiveRecoverFailedReceipt(eq(ReceiptStatusType.FAILED), eq(false));
+        verify(documentdb, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    @SneakyThrows
+    void recoverFailedReceiptMassiveWithoutSendNotificationDefaultsTrue() {
+        doReturn(Collections.singletonMap("status", ReceiptStatusType.FAILED.name())).when(requestMock).getQueryParameters();
+        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), eq(true));
+
+        // test execution
+        HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, documentdb, contextMock));
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(helpdeskServiceMock).massiveRecoverFailedReceipt(eq(ReceiptStatusType.FAILED), eq(true));
+        verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 }

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceiptTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/http/RecoverFailedReceiptTest.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -84,7 +86,7 @@ class RecoverFailedReceiptTest {
         Receipt recovered = Receipt.builder().status(ReceiptStatusType.INSERTED).build();
 
         doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
-        doReturn(recovered).when(helpdeskServiceMock).recoverFailedReceipt(failedReceipt);
+        doReturn(recovered).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
@@ -110,7 +112,7 @@ class RecoverFailedReceiptTest {
         assertEquals(HttpStatus.NOT_FOUND, response.getStatus());
         assertNotNull(response.getBody());
 
-        verify(helpdeskServiceMock, never()).recoverFailedReceipt(any());
+        verify(helpdeskServiceMock, never()).recoverFailedReceipt(any(), anyBoolean());
         verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 
@@ -131,7 +133,7 @@ class RecoverFailedReceiptTest {
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatus());
         assertNotNull(response.getBody());
 
-        verify(helpdeskServiceMock, never()).recoverFailedReceipt(any());
+        verify(helpdeskServiceMock, never()).recoverFailedReceipt(any(), anyBoolean());
         verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 
@@ -141,7 +143,7 @@ class RecoverFailedReceiptTest {
         Receipt failedReceipt = createFailedReceipt();
 
         doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
-        doThrow(BizEventUnprocessableEntityException.class).when(helpdeskServiceMock).recoverFailedReceipt(failedReceipt);
+        doThrow(BizEventUnprocessableEntityException.class).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
@@ -160,7 +162,7 @@ class RecoverFailedReceiptTest {
         Receipt failedReceipt = createFailedReceipt();
 
         doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
-        doThrow(BizEventNotFoundException.class).when(helpdeskServiceMock).recoverFailedReceipt(failedReceipt);
+        doThrow(BizEventNotFoundException.class).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
@@ -179,7 +181,7 @@ class RecoverFailedReceiptTest {
         Receipt failedReceipt = createFailedReceipt();
 
         doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
-        doThrow(BizEventBadRequestException.class).when(helpdeskServiceMock).recoverFailedReceipt(failedReceipt);
+        doThrow(BizEventBadRequestException.class).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
@@ -199,7 +201,7 @@ class RecoverFailedReceiptTest {
         Receipt recovered = Receipt.builder().status(ReceiptStatusType.FAILED).build();
 
         doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
-        doReturn(recovered).when(helpdeskServiceMock).recoverFailedReceipt(failedReceipt);
+        doReturn(recovered).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), anyBoolean());
 
         // test execution
         HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
@@ -211,6 +213,49 @@ class RecoverFailedReceiptTest {
 
         verify(documentdb).setValue(receiptCaptor.capture());
         assertNotNull(receiptCaptor.getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    void recoverFailedReceiptWithSendNotificationFalse() {
+        Receipt failedReceipt = createFailedReceipt();
+        Receipt recovered = Receipt.builder().status(ReceiptStatusType.INSERTED).build();
+
+        doReturn(Collections.singletonMap("sendNotification", "false")).when(requestMock).getQueryParameters();
+        doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
+        doReturn(recovered).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), eq(false));
+
+        // test execution
+        HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), eq(false));
+        verify(documentdb, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    @SneakyThrows
+    void recoverFailedReceiptWithoutSendNotificationDefaultsTrue() {
+        Receipt failedReceipt = createFailedReceipt();
+        Receipt recovered = Receipt.builder().status(ReceiptStatusType.INSERTED).build();
+
+        doReturn(failedReceipt).when(receiptCosmosServiceMock).getReceipt(EVENT_ID);
+        doReturn(recovered).when(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), eq(true));
+
+        // test execution
+        HttpResponseMessage response = assertDoesNotThrow(() -> sut.run(requestMock, EVENT_ID, documentdb, contextMock));
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(helpdeskServiceMock).recoverFailedReceipt(eq(failedReceipt), eq(true));
+        verify(documentdb, never()).setValue(receiptCaptor.capture());
     }
 
     private Receipt createFailedReceipt() {

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/schedule/RecoverFailedReceiptScheduledTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/schedule/RecoverFailedReceiptScheduledTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -52,9 +54,8 @@ class RecoverFailedReceiptScheduledTest {
     void recoverFailedReceiptScheduledSuccess() {
         sut = new RecoverFailedReceiptScheduled(helpdeskServiceMock);
 
-        doReturn(createMassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(ReceiptStatusType.FAILED);
-        doReturn(createMassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(ReceiptStatusType.INSERTED);
-
+        doReturn(createMassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(eq(ReceiptStatusType.FAILED), eq(true));
+        doReturn(createMassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(eq(ReceiptStatusType.INSERTED), eq(true));
         // test execution
         assertDoesNotThrow(() -> sut.run("info", documentdb, contextMock));
 
@@ -68,8 +69,8 @@ class RecoverFailedReceiptScheduledTest {
     void recoverFailedReceiptScheduledSuccessWithoutAction() {
         sut = new RecoverFailedReceiptScheduled(helpdeskServiceMock);
 
-        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(ReceiptStatusType.FAILED);
-        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(ReceiptStatusType.INSERTED);
+        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(eq(ReceiptStatusType.FAILED), eq(true));
+        doReturn(new MassiveRecoverResult()).when(helpdeskServiceMock).massiveRecoverFailedReceipt(eq(ReceiptStatusType.INSERTED), eq(true));
 
         // test execution
         assertDoesNotThrow(() -> sut.run("info", documentdb, contextMock));
@@ -91,7 +92,7 @@ class RecoverFailedReceiptScheduledTest {
         assertDoesNotThrow(() -> sut.run("info", documentdb, contextMock));
 
         verify(documentdb, never()).setValue(any());
-        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), anyBoolean());
     }
 
     private MassiveRecoverResult createMassiveRecoverResult() {

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/schedule/RecoverNotNotifiedReceiptScheduledTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/helpdesk/schedule/RecoverNotNotifiedReceiptScheduledTest.java
@@ -16,6 +16,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -69,7 +70,7 @@ class RecoverNotNotifiedReceiptScheduledTest {
         // test execution
         assertDoesNotThrow(() -> sut.processRecoverNotNotifiedScheduledTrigger("info", contextMock));
 
-        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class));
+        verify(helpdeskServiceMock, never()).massiveRecoverFailedReceipt(any(ReceiptStatusType.class), anyBoolean());
     }
 
     private MassiveRecoverResult createMassiveRecoverResult() {

--- a/src/test/java/it/gov/pagopa/receipt/pdf/datastore/service/impl/HelpdeskServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/datastore/service/impl/HelpdeskServiceImplTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -51,8 +52,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -98,7 +101,7 @@ class HelpdeskServiceImplTest {
         doReturn(CREATION_DATE).when(bizEventToReceiptServiceMock).getTransactionCreationDate(any());
         doReturn(buildReceipt()).when(bizEventToReceiptServiceMock).updateReceipt(any());
 
-        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         assertNotNull(result);
         assertEquals(EVENT_ID, result.getEventId());
@@ -118,7 +121,7 @@ class HelpdeskServiceImplTest {
     void recoverFailedReceipt_KO_BizEventNotFound() {
         doThrow(BizEventNotFoundException.class).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
 
-        assertThrows(BizEventNotFoundException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        assertThrows(BizEventNotFoundException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         verify(bizEventToReceiptServiceMock, never()).tokenizeFiscalCodes(any(), any(), any());
         verify(bizEventToReceiptServiceMock, never()).getTransactionCreationDate(any());
@@ -134,7 +137,7 @@ class HelpdeskServiceImplTest {
         bizEvent.setEventStatus(status);
         doReturn(bizEvent).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
 
-        assertThrows(BizEventBadRequestException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        assertThrows(BizEventBadRequestException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         verify(bizEventToReceiptServiceMock, never()).tokenizeFiscalCodes(any(), any(), any());
         verify(bizEventToReceiptServiceMock, never()).getTransactionCreationDate(any());
@@ -149,7 +152,7 @@ class HelpdeskServiceImplTest {
         bizEvent.setPayer(null);
         doReturn(bizEvent).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
 
-        assertThrows(BizEventBadRequestException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        assertThrows(BizEventBadRequestException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         verify(bizEventToReceiptServiceMock, never()).tokenizeFiscalCodes(any(), any(), any());
         verify(bizEventToReceiptServiceMock, never()).getTransactionCreationDate(any());
@@ -167,7 +170,7 @@ class HelpdeskServiceImplTest {
                         .build());
         doReturn(bizEvent).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
 
-        assertThrows(BizEventBadRequestException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        assertThrows(BizEventBadRequestException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         verify(bizEventToReceiptServiceMock, never()).tokenizeFiscalCodes(any(), any(), any());
         verify(bizEventToReceiptServiceMock, never()).getTransactionCreationDate(any());
@@ -181,7 +184,7 @@ class HelpdeskServiceImplTest {
         BizEvent bizEvent = generateValidBizEvent("2");
         doReturn(bizEvent).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
 
-        assertThrows(BizEventUnprocessableEntityException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        assertThrows(BizEventUnprocessableEntityException.class, () -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         verify(bizEventToReceiptServiceMock, never()).tokenizeFiscalCodes(any(), any(), any());
         verify(bizEventToReceiptServiceMock, never()).getTransactionCreationDate(any());
@@ -197,7 +200,7 @@ class HelpdeskServiceImplTest {
         doThrow(PDVTokenizerException.class)
                 .when(bizEventToReceiptServiceMock).tokenizeFiscalCodes(any(), any(Receipt.class), any(EventData.class));
 
-        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         assertNotNull(result);
         assertEquals(ReceiptStatusType.FAILED, result.getStatus());
@@ -226,7 +229,7 @@ class HelpdeskServiceImplTest {
         doReturn(CREATION_DATE).when(bizEventToReceiptServiceMock).getTransactionCreationDate(any());
         doReturn(receipt).when(bizEventToReceiptServiceMock).updateReceipt(any());
 
-        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         assertNotNull(result);
         assertEquals(ReceiptStatusType.FAILED, result.getStatus());
@@ -255,7 +258,7 @@ class HelpdeskServiceImplTest {
             return null;
         }).when(bizEventToReceiptServiceMock).handleSendMessageToQueue(any(), any(Receipt.class));
 
-        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build()));
+        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
 
         assertNotNull(result);
         assertEquals(ReceiptStatusType.NOT_QUEUE_SENT, result.getStatus());
@@ -467,9 +470,9 @@ class HelpdeskServiceImplTest {
     void massiveRecoverFailedReceipt_OK(ReceiptStatusType status) {
         doReturn(createIteratorFeedResponse(status))
                 .when(receiptCosmosServiceMock).getFailedReceiptByStatus(null, 100, status);
-        doReturn(Receipt.builder().status(ReceiptStatusType.INSERTED).build()).when(sut).recoverFailedReceipt(any());
+        doReturn(Receipt.builder().status(ReceiptStatusType.INSERTED).build()).when(sut).recoverFailedReceipt(any(), anyBoolean());
 
-        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(status));
+        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(status, true));
 
         assertNotNull(result);
         assertEquals(2, result.getSuccessCounter());
@@ -482,9 +485,9 @@ class HelpdeskServiceImplTest {
     void massiveRecoverFailedReceipt_KO_recoverError() {
         doReturn(createIteratorFeedResponse(ReceiptStatusType.FAILED))
                 .when(receiptCosmosServiceMock).getFailedReceiptByStatus(null, 100, ReceiptStatusType.FAILED);
-        doReturn(Receipt.builder().status(ReceiptStatusType.FAILED).build()).when(sut).recoverFailedReceipt(any());
+        doReturn(Receipt.builder().status(ReceiptStatusType.FAILED).build()).when(sut).recoverFailedReceipt(any(), anyBoolean());
 
-        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(ReceiptStatusType.FAILED));
+        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(ReceiptStatusType.FAILED, true));
 
         assertNotNull(result);
         assertEquals(0, result.getSuccessCounter());
@@ -498,9 +501,9 @@ class HelpdeskServiceImplTest {
     void massiveRecoverFailedReceipt_KO_recoverThrowException() {
         doReturn(createIteratorFeedResponse(ReceiptStatusType.FAILED))
                 .when(receiptCosmosServiceMock).getFailedReceiptByStatus(null, 100, ReceiptStatusType.FAILED);
-        doThrow(BizEventBadRequestException.class).when(sut).recoverFailedReceipt(any());
+        doThrow(BizEventBadRequestException.class).when(sut).recoverFailedReceipt(any(), anyBoolean());
 
-        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(ReceiptStatusType.FAILED));
+        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(ReceiptStatusType.FAILED, true));
 
         assertNotNull(result);
         assertEquals(0, result.getSuccessCounter());
@@ -553,6 +556,68 @@ class HelpdeskServiceImplTest {
         assertEquals(0, result.getSuccessCounter());
         assertEquals(2, result.getErrorCounter());
         assertEquals(0, result.getFailedCartList().size());
+    }
+    @Test
+    @SneakyThrows
+    void recoverFailedReceipt_OK_sendNotificationFalse() {
+        doReturn(generateValidBizEvent("1")).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
+        doAnswer(invocation -> {
+            EventData passed = invocation.getArgument(2);
+            passed.setDebtorFiscalCode(TOKENIZED_DEBTOR_FISCAL_CODE);
+            passed.setPayerFiscalCode(TOKENIZED_PAYER_FISCAL_CODE);
+            return null;
+        }).when(bizEventToReceiptServiceMock).tokenizeFiscalCodes(any(), any(Receipt.class), any(EventData.class));
+        doReturn(CREATION_DATE).when(bizEventToReceiptServiceMock).getTransactionCreationDate(any());
+        doReturn(buildReceipt()).when(bizEventToReceiptServiceMock).updateReceipt(any());
+
+        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), false));
+
+        assertNotNull(result);
+
+        ArgumentCaptor<Receipt> receiptCaptor = ArgumentCaptor.forClass(Receipt.class);
+        verify(bizEventToReceiptServiceMock).updateReceipt(receiptCaptor.capture());
+        assertEquals(Boolean.FALSE, receiptCaptor.getValue().getSendNotification());
+
+        verify(bizEventToReceiptServiceMock).handleSendMessageToQueue(anyList(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    void recoverFailedReceipt_OK_sendNotificationTrue() {
+        doReturn(generateValidBizEvent("1")).when(bizEventCosmosClientMock).getBizEventDocument(anyString());
+        doAnswer(invocation -> {
+            EventData passed = invocation.getArgument(2);
+            passed.setDebtorFiscalCode(TOKENIZED_DEBTOR_FISCAL_CODE);
+            passed.setPayerFiscalCode(TOKENIZED_PAYER_FISCAL_CODE);
+            return null;
+        }).when(bizEventToReceiptServiceMock).tokenizeFiscalCodes(any(), any(Receipt.class), any(EventData.class));
+        doReturn(CREATION_DATE).when(bizEventToReceiptServiceMock).getTransactionCreationDate(any());
+        doReturn(buildReceipt()).when(bizEventToReceiptServiceMock).updateReceipt(any());
+
+        Receipt result = assertDoesNotThrow(() -> sut.recoverFailedReceipt(Receipt.builder().eventId("id").build(), true));
+
+        assertNotNull(result);
+
+        ArgumentCaptor<Receipt> receiptCaptor = ArgumentCaptor.forClass(Receipt.class);
+        verify(bizEventToReceiptServiceMock).updateReceipt(receiptCaptor.capture());
+        assertEquals(Boolean.TRUE, receiptCaptor.getValue().getSendNotification());
+
+        verify(bizEventToReceiptServiceMock).handleSendMessageToQueue(anyList(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    void massiveRecoverFailedReceipt_OK_sendNotificationFalsePropagated() {
+        doReturn(createIteratorFeedResponse(ReceiptStatusType.FAILED))
+            .when(receiptCosmosServiceMock).getFailedReceiptByStatus(null, 100, ReceiptStatusType.FAILED);
+        doReturn(Receipt.builder().status(ReceiptStatusType.INSERTED).build()).when(sut).recoverFailedReceipt(any(), eq(false));
+
+        MassiveRecoverResult result = assertDoesNotThrow(() -> sut.massiveRecoverFailedReceipt(ReceiptStatusType.FAILED, false));
+
+        assertNotNull(result);
+        assertEquals(2, result.getSuccessCounter());
+
+        verify(sut, org.mockito.Mockito.times(2)).recoverFailedReceipt(any(), eq(false));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added the `sendNotification` field (`Boolean`) to the `Receipt` entity.
- Added the `sendNotification` parameter to `HelpdeskService.recoverFailedReceipt` and `HelpdeskService.massiveRecoverFailedReceipt`: the flag is set on the recovered receipt before it is persisted via `updateReceipt` and sent to the PDF generation queue.
- The `RecoverFailedReceipt` and `RecoverFailedReceiptMassive` HTTP functions now read an optional `sendNotification` query parameter (default: `true`) and propagate it to the recovery flow.
- The `RecoverFailedReceiptScheduled` timer function always recovers with `sendNotification=true`, preserving the current behavior of the automatic recovery.
- Updated existing tests to the new service signatures and added unit tests covering the propagation of the flag: on the service (flag set on the receipt persisted via `updateReceipt`, for both `true` and `false`), on the HTTP functions (query parameter read correctly, default `true` when missing), on the massive recovery (flag forwarded to the single recovery) and on the scheduled function (always `true`).

#### Motivation and Context

The receipt recovery APIs exposed by this microservice are being extended with an optional `sendNotification` parameter, allowing the Assistance team to decide at execution time whether a recovered receipt should trigger the notification to the IO app.

The parameter defaults to `true`, so the current behavior of the existing APIs remains unchanged. In case of massive recovery of historical receipts, the Assistance team will be able to call the API with `sendNotification=false`, avoiding unwanted notifications to end users for old payments.

The choice made by the API is persisted on the receipt before it is sent to the PDF generation queue. The `pagopa-receipt-pdf-generator` microservice, which consumes the queue and updates the receipt status after PDF generation, is updated with the companion change (see PR [PIDM-862] on `pagopa-receipt-pdf-generator`): if `sendNotification` is `true` or not set the receipt is moved to `GENERATED` as today, if it is `false` it is moved to `NOT_TO_NOTIFY`, so that the PDF is considered correctly generated without triggering the notification flow to the IO app.

This way the recovery API remains backward compatible, while allowing massive recoveries of old receipts to be handled correctly.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[PIDM-862]: https://pagopa.atlassian.net/browse/PIDM-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ